### PR TITLE
fix: default to white (light) theme regardless of OS preference

### DIFF
--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -199,8 +199,8 @@ function getStoredTheme(): ThemeId {
   } catch {
     // localStorage may be unavailable (SSR, private browsing, etc.)
   }
-  // No stored preference — respect OS dark/light mode
-  return getSystemTheme();
+  // No stored preference — always default to light theme
+  return DEFAULT_THEME;
 }
 
 function applyTheme(themeId: ThemeId) {


### PR DESCRIPTION
Previously, first-time visitors with dark OS preference would see `axiotic-dark`. Now always defaults to `axiotic-light` (white) when no stored preference exists. Users can still manually switch to dark via the theme toggle.

**Change:** `getStoredTheme()` returns `DEFAULT_THEME` (`axiotic-light`) instead of `getSystemTheme()` when there's no stored preference.